### PR TITLE
Added possibility to add custom overrides

### DIFF
--- a/fish/config.fish
+++ b/fish/config.fish
@@ -80,3 +80,8 @@ set tacklebox_plugins pip python extract
 
 # Load fishmarks (http://github.com/techwizrd/fishmarks)
 . $HOME/.fishmarks/marks.fish
+
+# Look for user defined overrides.
+if test -e ~/.config/fish/overrides.fish
+  . ~/.config/fish/overrides.fish
+end


### PR DESCRIPTION
Fixes #13 .

Changes proposed in this PR:
- Easy way for user to add custom overrides to certain variables in the config.

Path is hard-coded to the `~/.config/fish/overrides.fish` file.